### PR TITLE
Move CSBDeep menu up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	</parent>
 
 	<groupId>mpicbg.csbd</groupId>
-	<artifactId>CSBDeep</artifactId>
+	<artifactId>CSBDeep_</artifactId>
 	<version>0.2.1</version>
 
 	<name>CSBDeep</name>

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -1,0 +1,1 @@
+Plugins>CSBDeep>Demo,      "-",                                              null


### PR DESCRIPTION
Hey @frauzufall ,

with this change, the CSBDeep menu moves up in the normal alphabetical order of Plugin menus which makes it easier to find.

![image](https://user-images.githubusercontent.com/12660498/48659992-9d312500-ea5a-11e8-8aaf-cca247a48ac1.png)

In know it's just a nice-to-have, but maybe you also would like to have it ;-)

Cheers,
Robert